### PR TITLE
Inspect coreType later

### DIFF
--- a/src/coconut/data/macros/Models.hx
+++ b/src/coconut/data/macros/Models.hx
@@ -134,7 +134,6 @@ class Models {
 
           ret;  
         case TFun(_, _): [];   
-        case TAbstract(_.get() => a, _) if (!a.meta.has(':coreType') && check(a.type).length == 0): []; 
         case TAbstract(_.get().meta.has(':enum') => true, _): [];
         case TInst(_.get().kind => KTypeParameter(_), _): [];
         case TInst(_.get() => { pack: ['tink', 'state'], name: 'ObservableArray' | 'ObservableMap' }, params): checkMany(params);
@@ -151,6 +150,7 @@ class Models {
            | TInst(_.get().meta => m, params) if (m.has(':pure') || m.has(OBSERVABLE) || m.has(SKIP_CHECK)):
 
           checkMany(params);
+        case TAbstract(_.get() => a, _) if (!a.meta.has(':coreType') && check(a.type).length == 0): []; 
         case TEnum(_.get() => e, params):
 
           e.meta.add(SKIP_CHECK, [], e.pos);


### PR DESCRIPTION
I just updated one of my older projects to latest coconut and haxe4 rc1, and then https://github.com/MVCoconut/coconut.data/issues/12 pops up again while it was fine before the upgrade. Dunno what have changed causing the problem. But apparently this patch fixes it.

p.s. My problematic type is an abstract marked with `@:pure`, otherwise its underlying type is recursive. Since it is not tagged as `@:coreType`, `check(a.type)` triggered the recursion. So I moved that after the `@:pure` check.
