### PR TITLE
remove ambiguous sentence in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ class TodoSelection implements Model {
 
 If you have a `var todoList = new TodoList()`, then calling `todoList.annex.get(TodoSelection)` will return the same `TodoSelection` every time (it is created when requested the first time and then retained).
 
-This only makes sense, if you want the same associated state for the same model everywhere. You may well wish to have two separate selections for two todolist.
+This only makes sense, if you want the same associated state for the same model everywhere. 
 
 ### Static extensions with annex
 


### PR DESCRIPTION
In the Annex section of the README I propose to get rid of this sentence:

"You may well wish to have two separate selections for two todolist" 

I find it doubly ambiguous because:

1. `x.annex.get(TodoSelection)` always gives different instances of `TodoSelection` when object `x` varies,
2. to get two different filtering in two different instances of `TodoSelection` you could change the filter function.

So you have to go through 2 logical invalidation to deduce the real meaning, which I guess is something like "if that's not what you need don't use it". 

OTOH I like this style that forces you to think and read many times, but  the doc for `coconut.data` has already many concepts, it is better to not panick the reader by ambiguity :)