### PR TITLE
Reference to class member with explicit `this`

### DIFF
--- a/src/coconut/data/macros/ModelBuilder.hx
+++ b/src/coconut/data/macros/ModelBuilder.hx
@@ -459,7 +459,7 @@ class ModelBuilder {
         field: f.name,
         expr: switch kind {
           case KConstant:
-            macro @:pos(f.pos) tink.state.Observable.const($i{name} #if tink_state.debug , () -> this.toString() + '.' + $v{f.name} + '(' + $i{name} + ')' #end);
+            macro @:pos(f.pos) tink.state.Observable.const(this.$name #if tink_state.debug , () -> this.toString() + '.' + $v{f.name} + '(' + this.$name + ')' #end);
           default:
             macro @:pos(f.pos) $i{state}
         }


### PR DESCRIPTION
Before this fix the following code fails to build because the function argument is passed to `Observable.const` (instead of the underlying class member which actually stores the constant)

```haxe
class MyModel implements Model {
	@:constant var foo:Int;
	public function new(foo:Int) {
   		this = { foo: foo }
 	}
}
```